### PR TITLE
Change URL of markdown content

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -23,7 +23,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       createNodeField({
         node,
         name: 'slug',
-        value: slug || ''
+        value: `/${layout}${slug}` || ''
       })
 
       // Used to determine a page layout.


### PR DESCRIPTION
### What's new: :truck:
* page markdown files' path will start with `page/`
* post markdown files' path will start with `post/`

Closes #15 